### PR TITLE
Frame timing fix

### DIFF
--- a/samples/Basic/vc2013/Basic.vcxproj
+++ b/samples/Basic/vc2013/Basic.vcxproj
@@ -1,3 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug_ANGLE|Win32">
@@ -73,7 +74,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\include;"..\..\..\..\..\include";..\..\..\lib;..\..\..\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;"..\..\..\..\..\include";..\..\..\lib\imgui;..\..\..\include</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;NOMINMAX;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -131,7 +132,7 @@ xcopy /y "..\..\..\..\..\lib\msw\x86\d3dcompiler_46.dll" "$(OutDir)"</Command>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\include;"..\..\..\..\..\include";..\..\..\lib;..\..\..\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;"..\..\..\..\..\include";..\..\..\lib\imgui;..\..\..\include</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;NOMINMAX;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader />
@@ -189,6 +190,8 @@ xcopy /y "..\..\..\..\..\lib\msw\x86\d3dcompiler_46.dll" "$(OutDir)"</Command>
   <ItemGroup />
   <ItemGroup />
   <ItemGroup>
+    <ClCompile Include="..\..\..\lib\imgui\imgui_demo.cpp" />
+    <ClCompile Include="..\..\..\lib\imgui\imgui_draw.cpp" />
     <ClCompile Include="..\src\BasicApp.cpp" />
     <ClCompile Include="..\..\..\src\CinderImGui.cpp" />
     <ClCompile Include="..\..\..\lib\imgui\imgui.cpp" />

--- a/samples/Basic/vc2013/Basic.vcxproj.filters
+++ b/samples/Basic/vc2013/Basic.vcxproj.filters
@@ -1,3 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -57,6 +58,12 @@
       <Filter>Blocks\ImGui\src</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\lib\imgui\imgui.cpp">
+      <Filter>Blocks\ImGui\lib\imgui</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\lib\imgui\imgui_demo.cpp">
+      <Filter>Blocks\ImGui\lib\imgui</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\lib\imgui\imgui_draw.cpp">
       <Filter>Blocks\ImGui\lib\imgui</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/CinderImGui.cpp
+++ b/src/CinderImGui.cpp
@@ -219,7 +219,7 @@ ImGui::Options& ImGui::Options::darkTheme()
 	mStyle.ColumnsMinSpacing        = 50.0f;
 	mStyle.GrabMinSize				= 14.0f;
 	mStyle.GrabRounding				= 16.0f;
-	mStyle.ScrollbarWidth           = 12.0f;
+	mStyle.ScrollbarWidth			= 12.0f;
 	mStyle.ScrollbarRounding		= 16.0f;
 	
 	ImGuiStyle& style = mStyle;
@@ -877,7 +877,7 @@ void initialize( const Options &options )
 	imGuiStyle.WindowFillAlphaDefault   = style.WindowFillAlphaDefault;
 	imGuiStyle.IndentSpacing            = style.IndentSpacing;
 	imGuiStyle.ColumnsMinSpacing		= style.ColumnsMinSpacing;
-	imGuiStyle.ScrollbarWidth           = style.ScrollbarWidth;
+	imGuiStyle.ScrollbarWidth			= style.ScrollbarWidth;
 	imGuiStyle.ScrollbarRounding		= style.ScrollbarRounding;
 	imGuiStyle.GrabMinSize				= style.GrabMinSize;
 	imGuiStyle.GrabRounding				= style.GrabRounding;

--- a/src/CinderImGui.cpp
+++ b/src/CinderImGui.cpp
@@ -1136,14 +1136,12 @@ namespace {
 	static bool sNewFrame = false;
 	void render()
 	{
-		static float elapsedTime    = 0.0f;
-		float currentElapsedTime    = getElapsedSeconds();
+		static auto timer = ci::Timer(true);
 		ImGuiIO& io                 = ImGui::GetIO();
-		io.DeltaTime                = ( currentElapsedTime - elapsedTime );
-		elapsedTime                 = currentElapsedTime;
+		io.DeltaTime                = timer.getSeconds();
+		timer.start();
 		
 		ImGui::Render();
-		//sLastFrame                  = getElapsedFrames();
 		sNewFrame                   = false;
 		App::get()->dispatchAsync( [](){ ImGui::NewFrame(); sNewFrame = true; } );
 	}


### PR DESCRIPTION
Fixes issues with timing precision.

Over time (say 4 hours), floats lose precision and are unable to produce accurate frame time deltas. This causes strange gui behavior.

Additionally, I noticed this when an ImGui assertion about `DeltaTime >= 0.0f` failed. I'm not sure exactly what happened, but somehow the Cinder elapsed seconds subtraction resulted in a negative number `-0.0375f`.
