### PR TITLE
Fix frame timing loss of precision.

### DIFF
--- a/src/CinderImGui.cpp
+++ b/src/CinderImGui.cpp
@@ -1136,14 +1136,12 @@ namespace {
 	static bool sNewFrame = false;
 	void render()
 	{
-		static float elapsedTime    = 0.0f;
-		float currentElapsedTime    = getElapsedSeconds();
+		static auto timer = ci::Timer(true);
 		ImGuiIO& io                 = ImGui::GetIO();
-		io.DeltaTime                = ( currentElapsedTime - elapsedTime );
-		elapsedTime                 = currentElapsedTime;
+		io.DeltaTime                = timer.getSeconds();
+		timer.start();
 		
 		ImGui::Render();
-		//sLastFrame                  = getElapsedFrames();
 		sNewFrame                   = false;
 		App::get()->dispatchAsync( [](){ ImGui::NewFrame(); sNewFrame = true; } );
 	}


### PR DESCRIPTION
Fixes issues with timing precision.

Over time (say 4 hours), floats lose precision and are unable to produce accurate frame time deltas. This causes strange gui behavior.

Additionally, I noticed this when an ImGui assertion about DeltaTime >= 0.0f failed. I'm not sure exactly what happened, but somehow the Cinder elapsed seconds subtraction resulted in a negative number -0.0375f.
